### PR TITLE
Create Annotations Module

### DIFF
--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -38,35 +38,53 @@ impl BoundingBox {
             Ok(BoundingBox {left, top, right, bottom, category})
         }
     }
-
-    pub fn left(&self) -> f64 {
-        self.left
-    }
-
-    pub fn top(&self) -> f64 {
-        self.top
-    }
-
-    pub fn right(&self) -> f64 {
-        self.right
-    }
-
-    pub fn bottom(&self) -> f64 {
-        self.bottom
-    }
-
-    pub fn category(&self) -> &str {
-        &self.category
-    }
 }
 
-trait BoundingBoxGeometry {
+/// A trait providing methods for computing attributes about boxes.
+///
+/// Any annotation that uses a bounding box as its base has "box like geometry", and therefore can
+/// be passed in to useful functions like non-maximum suppression and intersection over union.
+pub trait BoundingBoxGeometry {
     fn left(&self) -> f64;
     fn top(&self) -> f64;
     fn right(&self) -> f64;
     fn bottom(&self) -> f64;
-    fn category(&self) -> f64;
+    fn category(&self) -> &str;
     fn area(&self) -> f64;
-    fn center(&self) -> f64;
-    fn xyxy(&self) -> f64;
+    fn center(&self) -> (f64, f64);
+    fn as_xyxy(&self) -> (f64, f64, f64, f64);
+}
+
+impl BoundingBoxGeometry for BoundingBox {
+    fn left(&self) -> f64 {
+        self.left
+    }
+
+    fn top(&self) -> f64 {
+        self.top
+    }
+
+    fn right(&self) -> f64 {
+        self.right
+    }
+
+    fn bottom(&self) -> f64 {
+        self.bottom
+    }
+
+    fn category(&self) -> &str {
+        &self.category
+    }
+
+    fn area(&self) -> f64 {
+        (self.right - self.left) * (self.bottom - self.top)
+    }
+
+    fn center(&self) -> (f64, f64) {
+        (0.5_f64*(self.right - self.left), 0.5_f64*(self.bottom - self.top))
+    }
+
+    fn as_xyxy(&self) -> (f64, f64, f64, f64) {
+        (self.left, self.top, self.right, self.bottom)
+    }
 }

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -53,4 +53,8 @@ impl BoundingBox {
     pub fn bottom(&self) -> f64 {
         self.bottom
     }
+
+    pub fn category(&self) -> String {
+        self.category
+    }
 }

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -54,7 +54,7 @@ impl BoundingBox {
         self.bottom
     }
 
-    pub fn category(&self) -> String {
-        self.category
+    pub fn category(&self) -> &str {
+        &self.category
     }
 }

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -3,7 +3,8 @@
 /// A bounding box is a rectangle used to annotate objects in images for training deep object
 /// detection models. An ideal bounding box is the smallest box that totally contains the
 /// object within the image. Bounding boxes are composed of a rectangle and a category denoting
-/// what object it is.
+/// what object it is. When an object detection model runs, it will output bounding boxes as its
+/// output along with a probability encoding its confidence in that box+category.
 ///
 /// This project uses the standard convention of the left side of the image being x=0 and the top
 /// of the image being y=0.

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -59,3 +59,14 @@ impl BoundingBox {
         &self.category
     }
 }
+
+trait BoundingBoxGeometry {
+    fn left(&self) -> f64;
+    fn top(&self) -> f64;
+    fn right(&self) -> f64;
+    fn bottom(&self) -> f64;
+    fn category(&self) -> f64;
+    fn area(&self) -> f64;
+    fn center(&self) -> f64;
+    fn xyxy(&self) -> f64;
+}

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -1,3 +1,27 @@
+use std::fmt;
+
+/// A set of custom errors for more informative error handling.
+#[derive(Debug)]
+pub enum BoundingBoxError {
+    InvalidLeftRight {left: f64, right: f64},
+    InvalidTopBottom {top: f64, bottom: f64}
+}
+
+impl fmt::Display for BoundingBoxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BoundingBoxError::InvalidLeftRight {left, right} => {
+                write!(f, "Failed to create BoundingBox, left ({}) > right ({}).", left, right)
+            }
+            BoundingBoxError::InvalidTopBottom {top, bottom} => {
+                write!(f, "Failed to create BoundingBox, top ({}) > bottom ({}).", top, bottom)
+            }
+        }
+    }
+}
+
+impl std::error::Error for BoundingBoxError {}
+
 /// A struct representing a bounding box.
 /// 
 /// A bounding box is a rectangle used to annotate objects in images for training deep object
@@ -21,19 +45,11 @@ impl BoundingBox {
     /// Checks if a box has valid parameters before constructing.
     pub fn new(
         left: f64, top: f64, right: f64, bottom: f64, category: String
-    ) -> Result<Self, String> {
+    ) -> Result<Self, BoundingBoxError> {
         if left > right {
-            Err(format!(
-                "Failed to create BoundingBox, value for left > value for right ({} > {}).",
-                left,
-                right
-            ))
+            Err(BoundingBoxError::InvalidLeftRight {left, right})
         } else if top > bottom {
-            Err(format!(
-                "Failed to create BoundingBox, value for top > value for bottom ({} > {}).",
-                top,
-                bottom
-            ))
+            Err(BoundingBoxError::InvalidTopBottom {top, bottom})
         } else {
             Ok(BoundingBox {left, top, right, bottom, category})
         }

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 /// A struct representing a bounding box.
 /// 
 /// A bounding box is a rectangle used to annotate objects in images for training deep object
@@ -25,7 +23,7 @@ impl BoundingBox {
     ) -> Result<Self, String> {
         if left > right {
             Err(format!(
-                "Failed to create BoundingBox, value for left > value for right ({} > {})",
+                "Failed to create BoundingBox, value for left > value for right ({} > {}).",
                 left,
                 right
             ))
@@ -39,6 +37,20 @@ impl BoundingBox {
             Ok(BoundingBox {left, top, right, bottom, category})
         }
     }
-}
 
-pub trait BoundingBoxOperations {}
+    pub fn left(&self) -> f64 {
+        self.left
+    }
+
+    pub fn top(&self) -> f64 {
+        self.top
+    }
+
+    pub fn right(&self) -> f64 {
+        self.right
+    }
+
+    pub fn bottom(&self) -> f64 {
+        self.bottom
+    }
+}

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -3,18 +3,26 @@ use std::fmt;
 /// A set of custom errors for more informative error handling.
 #[derive(Debug)]
 pub enum BoundingBoxError {
-    InvalidLeftRight {left: f64, right: f64},
-    InvalidTopBottom {top: f64, bottom: f64}
+    InvalidLeftRight { left: f64, right: f64 },
+    InvalidTopBottom { top: f64, bottom: f64 },
 }
 
 impl fmt::Display for BoundingBoxError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BoundingBoxError::InvalidLeftRight {left, right} => {
-                write!(f, "Failed to create BoundingBox, left ({}) > right ({}).", left, right)
+            BoundingBoxError::InvalidLeftRight { left, right } => {
+                write!(
+                    f,
+                    "Failed to create BoundingBox, left ({}) > right ({}).",
+                    left, right
+                )
             }
-            BoundingBoxError::InvalidTopBottom {top, bottom} => {
-                write!(f, "Failed to create BoundingBox, top ({}) > bottom ({}).", top, bottom)
+            BoundingBoxError::InvalidTopBottom { top, bottom } => {
+                write!(
+                    f,
+                    "Failed to create BoundingBox, top ({}) > bottom ({}).",
+                    top, bottom
+                )
             }
         }
     }
@@ -23,7 +31,7 @@ impl fmt::Display for BoundingBoxError {
 impl std::error::Error for BoundingBoxError {}
 
 /// A struct representing a bounding box.
-/// 
+///
 /// A bounding box is a rectangle used to annotate objects in images for training deep object
 /// detection models. An ideal bounding box is the smallest box that totally contains the
 /// object within the image. Bounding boxes are composed of a rectangle and a category denoting
@@ -38,20 +46,30 @@ pub struct BoundingBox {
     top: f64,
     right: f64,
     bottom: f64,
-    category: String
+    category: String,
 }
 
 impl BoundingBox {
     /// Checks if a box has valid parameters before constructing.
     pub fn new(
-        left: f64, top: f64, right: f64, bottom: f64, category: String
+        left: f64,
+        top: f64,
+        right: f64,
+        bottom: f64,
+        category: String,
     ) -> Result<Self, BoundingBoxError> {
         if left > right {
-            Err(BoundingBoxError::InvalidLeftRight {left, right})
+            Err(BoundingBoxError::InvalidLeftRight { left, right })
         } else if top > bottom {
-            Err(BoundingBoxError::InvalidTopBottom {top, bottom})
+            Err(BoundingBoxError::InvalidTopBottom { top, bottom })
         } else {
-            Ok(BoundingBox {left, top, right, bottom, category})
+            Ok(BoundingBox {
+                left,
+                top,
+                right,
+                bottom,
+                category,
+            })
         }
     }
 }
@@ -107,7 +125,10 @@ impl BoundingBoxGeometry for BoundingBox {
     }
 
     fn center(&self) -> (f64, f64) {
-        (0.5_f64*(self.right - self.left), 0.5_f64*(self.bottom - self.top))
+        (
+            0.5_f64 * (self.right - self.left),
+            0.5_f64 * (self.bottom - self.top),
+        )
     }
 
     fn as_xyxy(&self) -> (f64, f64, f64, f64) {

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -1,0 +1,44 @@
+use std::fmt;
+
+/// A struct representing a bounding box.
+/// 
+/// A bounding box is a rectangle used to annotate objects in images for training deep object
+/// detection models. An ideal bounding box is the smallest box that totally contains the
+/// object within the image. Bounding boxes are composed of a rectangle and a category denoting
+/// what object it is.
+///
+/// This project uses the standard convention of the left side of the image being x=0 and the top
+/// of the image being y=0.
+#[derive(Debug)]
+pub struct BoundingBox {
+    left: f64,
+    top: f64,
+    right: f64,
+    bottom: f64,
+    category: String
+}
+
+impl BoundingBox {
+    /// Checks if a box has valid parameters before constructing.
+    pub fn new(
+        left: f64, top: f64, right: f64, bottom: f64, category: String
+    ) -> Result<Self, String> {
+        if left > right {
+            Err(format!(
+                "Failed to create BoundingBox, value for left > value for right ({} > {})",
+                left,
+                right
+            ))
+        } else if top > bottom {
+            Err(format!(
+                "Failed to create BoundingBox, value for top > value for bottom ({} > {}).",
+                top,
+                bottom
+            ))
+        } else {
+            Ok(BoundingBox {left, top, right, bottom, category})
+        }
+    }
+}
+
+pub trait BoundingBoxOperations {}

--- a/src/annotations/bounding_box.rs
+++ b/src/annotations/bounding_box.rs
@@ -56,6 +56,16 @@ impl BoundingBox {
     }
 }
 
+impl fmt::Display for BoundingBox {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "BoundingBox {{ left: {}, top: {}, right: {}, bottom: {}, category: {}}}",
+            self.left, self.top, self.right, self.bottom, self.category
+        )
+    }
+}
+
 /// A trait providing methods for computing attributes about boxes.
 ///
 /// Any annotation that uses a bounding box as its base has "box like geometry", and therefore can

--- a/src/annotations/bounding_box_with_keypoint.rs
+++ b/src/annotations/bounding_box_with_keypoint.rs
@@ -34,9 +34,19 @@ impl BoundingBoxWithKeypoint {
         Ok(BoundingBoxWithKeypoint {bounding_box, keypoint})
     }
 
-    pub fn left(&self) -> f64 {0_f64}
-    pub fn top(&self) -> f64 {0_f64}
-    pub fn right(&self) -> f64 {0_f64}
-    pub fn bottom(&self) -> f64 {0_f64}
-    pub fn category(&self) -> &str {&""}
+    pub fn left(&self) -> f64 {
+        self.bounding_box.left()
+    }
+    pub fn top(&self) -> f64 {
+        self.bounding_box.top()
+    }
+    pub fn right(&self) -> f64 {
+        self.bounding_box.right()
+    }
+    pub fn bottom(&self) -> f64 {
+        self.bounding_box.bottom()
+    }
+    pub fn category(&self) -> &str {
+        self.bounding_box.category()
+    }
 }

--- a/src/annotations/bounding_box_with_keypoint.rs
+++ b/src/annotations/bounding_box_with_keypoint.rs
@@ -1,5 +1,5 @@
-use annotations::bounding_box::{BoundingBox};
-use annotations::point::{Point};
+use crate::annotations::bounding_box::{BoundingBox};
+use crate::annotations::point::{Point};
 
 /// A struct representing a BoundingBox + Keypoint annotation.
 ///
@@ -7,7 +7,7 @@ use annotations::point::{Point};
 /// to place keypoints into the frame as well. Therefore, the output of pose models is both a
 /// bounding box as well as a list of points relating to the "pose" of the object. For this project
 /// we only have pose models that predict a single keypoint.
-#[Derive(Debug)]
+#[derive(Debug)]
 pub struct BoundingBoxWithKeypoint {
     bounding_box: BoundingBox,
     keypoint: Point
@@ -22,11 +22,21 @@ impl BoundingBoxWithKeypoint {
         keypoint_x: f64,
         keypoint_y: f64,
         category: String
-    ) -> Result<BoundingBoxWithKeypoint, String> {}
+    ) -> Result<BoundingBoxWithKeypoint, String> {
+        let bbox: Result<BoundingBox, String> = BoundingBox::new(
+            left, top, right, bottom, category
+        );
+        let bounding_box: BoundingBox = match bbox {
+            Ok(b) => b,
+            Err(s) => return Err(s)
+        };
+        let keypoint: Point = Point {x: keypoint_x, y: keypoint_y};
+        Ok(BoundingBoxWithKeypoint {bounding_box, keypoint})
+    }
 
-    pub fn left() -> f64 {}
-    pub fn top() -> f64 {}
-    pub fn right() -> f64 {}
-    pub fn bottom() -> f64 {}
-    pub fn category() -> f64 {}
+    pub fn left(&self) -> f64 {0_f64}
+    pub fn top(&self) -> f64 {0_f64}
+    pub fn right(&self) -> f64 {0_f64}
+    pub fn bottom(&self) -> f64 {0_f64}
+    pub fn category(&self) -> &str {&""}
 }

--- a/src/annotations/bounding_box_with_keypoint.rs
+++ b/src/annotations/bounding_box_with_keypoint.rs
@@ -1,5 +1,6 @@
 use crate::annotations::bounding_box::{BoundingBox, BoundingBoxError, BoundingBoxGeometry};
 use crate::annotations::point::{Point};
+use std::fmt;
 
 /// A struct representing a BoundingBox + Keypoint annotation.
 ///
@@ -27,6 +28,16 @@ impl BoundingBoxWithKeypoint {
             bounding_box: BoundingBox::new(left, top, right, bottom, category)?,
             keypoint: Point {x: keypoint_x, y: keypoint_y}
         })
+    }
+}
+
+impl fmt::Display for BoundingBoxWithKeypoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "BoundingBoxWithKeypoint {{ bounding_box: {}, keypoint: {}}}",
+            self.bounding_box, self.keypoint
+        )
     }
 }
 

--- a/src/annotations/bounding_box_with_keypoint.rs
+++ b/src/annotations/bounding_box_with_keypoint.rs
@@ -1,0 +1,32 @@
+use annotations::bounding_box::{BoundingBox};
+use annotations::point::{Point};
+
+/// A struct representing a BoundingBox + Keypoint annotation.
+///
+/// Pose estimation models use a standard detection model as their base, and add on functionality
+/// to place keypoints into the frame as well. Therefore, the output of pose models is both a
+/// bounding box as well as a list of points relating to the "pose" of the object. For this project
+/// we only have pose models that predict a single keypoint.
+#[Derive(Debug)]
+pub struct BoundingBoxWithKeypoint {
+    bounding_box: BoundingBox,
+    keypoint: Point
+}
+
+impl BoundingBoxWithKeypoint {
+    pub fn new(
+        left: f64,
+        top: f64,
+        right: f64,
+        bottom: f64,
+        keypoint_x: f64,
+        keypoint_y: f64,
+        category: String
+    ) -> Result<BoundingBoxWithKeypoint, String> {}
+
+    pub fn left() -> f64 {}
+    pub fn top() -> f64 {}
+    pub fn right() -> f64 {}
+    pub fn bottom() -> f64 {}
+    pub fn category() -> f64 {}
+}

--- a/src/annotations/bounding_box_with_keypoint.rs
+++ b/src/annotations/bounding_box_with_keypoint.rs
@@ -1,4 +1,4 @@
-use crate::annotations::bounding_box::{BoundingBox, BoundingBoxGeometry};
+use crate::annotations::bounding_box::{BoundingBox, BoundingBoxError, BoundingBoxGeometry};
 use crate::annotations::point::{Point};
 
 /// A struct representing a BoundingBox + Keypoint annotation.
@@ -22,7 +22,7 @@ impl BoundingBoxWithKeypoint {
         keypoint_x: f64,
         keypoint_y: f64,
         category: String
-    ) -> Result<BoundingBoxWithKeypoint, String> {
+    ) -> Result<BoundingBoxWithKeypoint, BoundingBoxError> {
         Ok(BoundingBoxWithKeypoint {
             bounding_box: BoundingBox::new(left, top, right, bottom, category)?,
             keypoint: Point {x: keypoint_x, y: keypoint_y}

--- a/src/annotations/bounding_box_with_keypoint.rs
+++ b/src/annotations/bounding_box_with_keypoint.rs
@@ -1,5 +1,5 @@
 use crate::annotations::bounding_box::{BoundingBox, BoundingBoxError, BoundingBoxGeometry};
-use crate::annotations::point::{Point};
+use crate::annotations::point::Point;
 use std::fmt;
 
 /// A struct representing a BoundingBox + Keypoint annotation.
@@ -11,7 +11,7 @@ use std::fmt;
 #[derive(Debug)]
 pub struct BoundingBoxWithKeypoint {
     bounding_box: BoundingBox,
-    keypoint: Point
+    keypoint: Point,
 }
 
 impl BoundingBoxWithKeypoint {
@@ -22,11 +22,14 @@ impl BoundingBoxWithKeypoint {
         bottom: f64,
         keypoint_x: f64,
         keypoint_y: f64,
-        category: String
+        category: String,
     ) -> Result<BoundingBoxWithKeypoint, BoundingBoxError> {
         Ok(BoundingBoxWithKeypoint {
             bounding_box: BoundingBox::new(left, top, right, bottom, category)?,
-            keypoint: Point {x: keypoint_x, y: keypoint_y}
+            keypoint: Point {
+                x: keypoint_x,
+                y: keypoint_y,
+            },
         })
     }
 }

--- a/src/annotations/bounding_box_with_keypoint.rs
+++ b/src/annotations/bounding_box_with_keypoint.rs
@@ -1,4 +1,4 @@
-use crate::annotations::bounding_box::{BoundingBox};
+use crate::annotations::bounding_box::{BoundingBox, BoundingBoxGeometry};
 use crate::annotations::point::{Point};
 
 /// A struct representing a BoundingBox + Keypoint annotation.
@@ -33,20 +33,38 @@ impl BoundingBoxWithKeypoint {
         let keypoint: Point = Point {x: keypoint_x, y: keypoint_y};
         Ok(BoundingBoxWithKeypoint {bounding_box, keypoint})
     }
+}
 
-    pub fn left(&self) -> f64 {
+impl BoundingBoxGeometry for BoundingBoxWithKeypoint {
+    fn left(&self) -> f64 {
         self.bounding_box.left()
     }
-    pub fn top(&self) -> f64 {
+
+    fn top(&self) -> f64 {
         self.bounding_box.top()
     }
-    pub fn right(&self) -> f64 {
+
+    fn right(&self) -> f64 {
         self.bounding_box.right()
     }
-    pub fn bottom(&self) -> f64 {
+
+    fn bottom(&self) -> f64 {
         self.bounding_box.bottom()
     }
-    pub fn category(&self) -> &str {
+
+    fn category(&self) -> &str {
         self.bounding_box.category()
+    }
+
+    fn area(&self) -> f64 {
+        self.bounding_box.area()
+    }
+
+    fn center(&self) -> (f64, f64) {
+        self.bounding_box.center()
+    }
+
+    fn as_xyxy(&self) -> (f64, f64, f64, f64) {
+        self.bounding_box.as_xyxy()
     }
 }

--- a/src/annotations/bounding_box_with_keypoint.rs
+++ b/src/annotations/bounding_box_with_keypoint.rs
@@ -23,15 +23,10 @@ impl BoundingBoxWithKeypoint {
         keypoint_y: f64,
         category: String
     ) -> Result<BoundingBoxWithKeypoint, String> {
-        let bbox: Result<BoundingBox, String> = BoundingBox::new(
-            left, top, right, bottom, category
-        );
-        let bounding_box: BoundingBox = match bbox {
-            Ok(b) => b,
-            Err(s) => return Err(s)
-        };
-        let keypoint: Point = Point {x: keypoint_x, y: keypoint_y};
-        Ok(BoundingBoxWithKeypoint {bounding_box, keypoint})
+        Ok(BoundingBoxWithKeypoint {
+            bounding_box: BoundingBox::new(left, top, right, bottom, category)?,
+            keypoint: Point {x: keypoint_x, y: keypoint_y}
+        })
     }
 }
 

--- a/src/annotations/detection.rs
+++ b/src/annotations/detection.rs
@@ -1,0 +1,11 @@
+use crate::annotations::bounding_box::{BoundingBoxGeometry};
+
+/// A detection is what is produced as output from an object detection model.
+///
+/// A detection is any annotation combined with a confidence score: a probability value that
+/// encodes the model's belief that the detection is true.
+#[derive(Debug)]
+pub struct Detection<T: BoundingBoxGeometry> {
+    pub annotation: T,
+    pub confidence: f64
+}

--- a/src/annotations/detection.rs
+++ b/src/annotations/detection.rs
@@ -1,4 +1,4 @@
-use crate::annotations::bounding_box::{BoundingBoxGeometry};
+use crate::annotations::bounding_box::BoundingBoxGeometry;
 use std::fmt;
 
 /// A detection is what is produced as output from an object detection model.
@@ -8,13 +8,15 @@ use std::fmt;
 #[derive(Debug)]
 pub struct Detection<T: BoundingBoxGeometry + fmt::Display> {
     pub annotation: T,
-    pub confidence: f64
+    pub confidence: f64,
 }
 
 impl<T: BoundingBoxGeometry + fmt::Display> fmt::Display for Detection<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
-            f, "Detection {{ annotation: {}, confidence: {} }}", self.annotation, self.confidence
+            f,
+            "Detection {{ annotation: {}, confidence: {} }}",
+            self.annotation, self.confidence
         )
     }
 }

--- a/src/annotations/detection.rs
+++ b/src/annotations/detection.rs
@@ -1,11 +1,20 @@
 use crate::annotations::bounding_box::{BoundingBoxGeometry};
+use std::fmt;
 
 /// A detection is what is produced as output from an object detection model.
 ///
 /// A detection is any annotation combined with a confidence score: a probability value that
 /// encodes the model's belief that the detection is true.
 #[derive(Debug)]
-pub struct Detection<T: BoundingBoxGeometry> {
+pub struct Detection<T: BoundingBoxGeometry + fmt::Display> {
     pub annotation: T,
     pub confidence: f64
+}
+
+impl<T: BoundingBoxGeometry + fmt::Display> fmt::Display for Detection<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f, "Detection {{ annotation: {}, confidence: {} }}", self.annotation, self.confidence
+        )
+    }
 }

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,0 +1,1 @@
+pub mod bounding_box;

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,2 +1,3 @@
 pub mod bounding_box;
+pub mod bounding_box_with_keypoint;
 pub mod point;

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,3 +1,4 @@
 pub mod bounding_box;
 pub mod bounding_box_with_keypoint;
+pub mod detection;
 pub mod point;

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,1 +1,2 @@
 pub mod bounding_box;
+pub mod point;

--- a/src/annotations/point.rs
+++ b/src/annotations/point.rs
@@ -4,7 +4,7 @@ use std::fmt;
 #[derive(Debug)]
 pub struct Point {
     pub x: f64,
-    pub y: f64
+    pub y: f64,
 }
 
 impl fmt::Display for Point {

--- a/src/annotations/point.rs
+++ b/src/annotations/point.rs
@@ -1,6 +1,6 @@
 /// A struct representing a simple point.
 #[derive(Debug)]
 pub struct Point {
-    x: f64,
-    y: f64
+    pub x: f64,
+    pub y: f64
 }

--- a/src/annotations/point.rs
+++ b/src/annotations/point.rs
@@ -1,0 +1,6 @@
+/// A struct representing a simple point.
+#[derive(Debug)]
+pub struct Point {
+    x: f64,
+    y: f64
+}

--- a/src/annotations/point.rs
+++ b/src/annotations/point.rs
@@ -1,6 +1,14 @@
+use std::fmt;
+
 /// A struct representing a simple point.
 #[derive(Debug)]
 pub struct Point {
     pub x: f64,
     pub y: f64
+}
+
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Point {{ x: {}, y: {} }}", self.x, self.y)
+    }
 }


### PR DESCRIPTION
This module makes up half of the utilities module from the original ChartExtractor repo. It contains the data structures rewritten in a more Rust-like fashion.