### PR TITLE
Add coherent point drift

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 image = "0.25.6"
 imageproc = "0.25.0"
+itertools = "0.14.0"
 ndarray = "0.16.1"
 ndarray-linalg = { version = "0.17.0", features = ["openblas-static"] }
 openblas-src = "0.10.11"

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -15,7 +15,7 @@ struct CoherentPointDriftTransform {
     sigma2: f32,
     num_target_points: usize,
     num_source_points: usize,
-    D: usize,
+    dimensions: usize,
     tolerance: f32,
     w: f32,
     max_iterations: u32,
@@ -58,7 +58,7 @@ impl CoherentPointDriftTransform {
             sigma2: initialize_sigma2(&X, &Y),
             num_target_points: num_target_points,
             num_source_points: num_source_points,
-            D: dimensions,
+            dimensions: dimensions,
             tolerance: tolerance.unwrap_or(0.001),
             w: w.unwrap_or(0.0),
             max_iterations: max_iterations.unwrap_or(100),
@@ -106,7 +106,7 @@ impl CoherentPointDriftTransform {
         let mut P = ((compute_diff(&self.X, &self.TY)).powi(2)).sum_axis(Axis(2));
         P = (-P/(2_f32*self.sigma2)).exp();
         let c = {
-            let left = (2.0*PI*self.sigma2).powf((self.D as f32)/2.0);
+            let left = (2.0*PI*self.sigma2).powf((self.dimensions as f32)/2.0);
             let right = self.w/(1.0-self.w)*(self.num_source_points as f32)/(self.num_target_points as f32);
             left * right
         };
@@ -143,7 +143,7 @@ impl CoherentPointDriftTransform {
         let yPy = self.P1.clone().t().dot(&self.TY.clone().powi(2).sum_axis(Axis(1)));
         let trPXY = (self.TY.clone()*self.PX.clone()).sum();
 
-        self.sigma2 = (xPx - 2.0 * trPXY + yPy) / (self.Np * self.D as f32);
+        self.sigma2 = (xPx - 2.0 * trPXY + yPy) / (self.Np * self.dimensions as f32);
         if self.sigma2 <= 0.0 {
             self.sigma2 = self.tolerance / 10.0;
         }
@@ -184,11 +184,11 @@ fn initialize_sigma2(
     Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>
 ) -> f32 {
     let num_target_points = X.dim().0 as f32;
-    let D = X.dim().1 as f32;
+    let dimensions = X.dim().1 as f32;
     let num_source_points = Y.dim().0 as f32;
     let diff = compute_diff(X, Y);
     let err = diff.powi(2);
-    err.sum()/(D*num_target_points*num_source_points)
+    err.sum()/(dimensions*num_target_points*num_source_points)
 }
 
 fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -161,9 +161,7 @@ fn gaussian_kernel(
     B: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     beta: f32,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
-    let A = A.clone();
-    let B = B.clone();
-    let sum_sq_dists = compute_squared_euclidean_distance(&A, &B);
+    let sum_sq_dists = compute_squared_euclidean_distance(A, B);
     (-sum_sq_dists / (2.0 * beta.powi(2))).exp()
 }
 

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -82,8 +82,8 @@ impl CoherentPointDriftTransform {
     }
 
     fn expectation(&mut self) {
-        let mut P = compute_squared_distance(&self.target_points, &self.transformed_points);
-        P = (-P / (2_f32 * self.variance)).exp();
+        let mut new_probabilities = compute_squared_distance(&self.target_points, &self.transformed_points);
+        new_probabilities = (-new_probabilities / (2_f32 * self.variance)).exp();
         let c = {
             let num_target_points: usize = self.target_points.dim().0;
             let dimensions: usize = self.target_points.dim().1;
@@ -94,10 +94,10 @@ impl CoherentPointDriftTransform {
                 / (num_target_points as f32);
             left * right
         };
-        let mut den = P.sum_axis(Axis(0));
+        let mut den = new_probabilities.sum_axis(Axis(0));
         den = den.mapv(|v| if v == 0.0 { f32::EPSILON + c } else { v + c });
 
-        self.probability_of_match = P / den;
+        self.probability_of_match = new_probabilities / den;
     }
 
     fn maximization(&mut self) {

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -16,7 +16,7 @@ struct CoherentPointDriftTransform {
     tolerance: f32,
     w: f32,
     max_iterations: u32,
-    diff: f32,
+    change_in_variance: f32,
     P: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     W: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     num_eig: u32,
@@ -49,7 +49,7 @@ impl CoherentPointDriftTransform {
             tolerance: tolerance.unwrap_or(0.001),
             w: w.unwrap_or(0.0),
             max_iterations: max_iterations.unwrap_or(100),
-            diff: f32::MAX,
+            change_in_variance: f32::MAX,
             P: Array::zeros((num_source_points, num_target_points)),
             W: Array::zeros((num_source_points, dimensions)),
             num_eig: num_eig.unwrap_or(100),
@@ -60,8 +60,8 @@ impl CoherentPointDriftTransform {
 
     pub fn register(&mut self) {
         self.transform_point_cloud(&gaussian_kernel(&self.Y, &self.Y, self.beta));
-        let iteration = 0;
-        while iteration < self.max_iterations && self.diff > self.tolerance {
+        let mut iteration = 0;
+        while iteration < self.max_iterations && self.change_in_variance > self.tolerance {
             if self.debug {
                 self.history
                     .push(format!("\"{}\": {}", iteration, array_to_string(&self.TY)));
@@ -146,7 +146,7 @@ impl CoherentPointDriftTransform {
         if self.sigma2 <= 0.0 {
             self.sigma2 = self.tolerance / 10.0;
         }
-        self.diff = (self.sigma2 - qprev).abs();
+        self.change_in_variance = (self.sigma2 - qprev).abs();
     }
 }
 

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -174,6 +174,7 @@ fn compute_diff(
     X_3d - Y_3d
 }
 
+/// Computes the gaussian kernel for CPD.
 fn gaussian_kernel(
     X: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
@@ -185,6 +186,7 @@ fn gaussian_kernel(
     (-diff / (2.0 * beta.powi(2))).exp()
 }
 
+/// Initializes sigma squared.
 fn initialize_sigma2(
     X: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
@@ -197,6 +199,8 @@ fn initialize_sigma2(
     err.sum() / (dimensions * num_target_points * num_source_points)
 }
 
+
+/// A helper function for converting a 2d array into a string representation.
 fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
     let mut arr_str = String::from("[");
     let arr = arr.clone();
@@ -216,6 +220,11 @@ fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
     arr_str
 }
 
+/// Computes the solution for a matrix equation AX = B.
+///
+/// Goes column by column through B to find the vector that
+/// solves that equation and then contatenates all the solution
+/// vectors as columns in the resulting matrix.
 fn solve_matrices(
     A: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     B: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -71,7 +71,7 @@ impl CoherentPointDriftTransform {
                 self.history.push(format!(
                     "\"{}\": {}",
                     iteration,
-                    array_to_string(&self.transformed_points)
+                    array_to_json_string(&self.transformed_points)
                 ));
             }
             self.expectation();
@@ -232,7 +232,11 @@ fn update_variance(
 }
 
 /// A helper function for converting a 2d array into a string representation.
-fn array_to_string(array: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
+///
+/// Used for debugging CoherentPointDriftTransform. When debug is set to true,
+/// the transformed point cloud is dumped to a json formatted string using
+/// this function.
+fn array_to_json_string(array: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
     let mut array_str = String::from("[");
     let array = array.clone();
     let chunks = array.into_iter().chunks(2);

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -7,22 +7,40 @@ use std::f32::EPSILON;
 use std::f32::consts::PI;
 
 struct CoherentPointDriftTransform {
+    /// The points to try to move the source towards.
     target_points: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    /// The points to move towards the target points. May contain outliers or
+    /// missing points.
     source_points: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    /// The tradeoff between the goodness of maximum likelihood fit and regularlization.
     lambda: f32,
+    /// The width of the smoothing Gaussian filter.
     beta: f32,
+    /// The source points after they have been moved by the cpd algorithm.
     transformed_points: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    /// The variance of the Gaussian mixture model.
     variance: f32,
+    /// A parameter that can end the iteration process early if the change in variance
+    /// is less than the tolerance.
     tolerance: f32,
+    /// The weight of the uniform distribution. Must be between 0 and 1.
+    /// See the coherent point drift paper for more details.
     weight_of_uniform_dist: f32,
+    /// The maximum number of iterations to perform.
     max_iterations: u32,
+    /// The change in variance between the previous iteration and the current one.
     change_in_variance: f32,
+    /// An MxN matrix containing the probability that a point from the target_points
+    /// set matches with a point from the source_points set.
     probability_of_match: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    /// A matrix which, when linearly combined with the gaussian kernel, contains
+    /// A matrix which, when linearly combined with the Gaussian kernel, contains
     /// the optimal displacement field to align the source points to the target.
     w_coefs: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    history: Vec<String>, // Contains all the transformed_points matrices for all iterations.
-    debug: bool,          // Whether or not to take a history.
+    /// A vector of json formatted lists containing the transformed_points at all
+    /// iterations. Use with caution, and set max_iterations low to start.
+    history: Vec<String>,
+    /// Whether or not to record the history of the transformed points.
+    debug: bool,
 }
 
 impl CoherentPointDriftTransform {

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -194,14 +194,14 @@ fn update_transform(
     lambda: f32,
     variance: f32,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
-    let A = {
+    let matrix_a = {
         let num_source_points: usize = source_points.dim().0;
         let left_term = Array::from_diag(sum_of_probability_rows).dot(gaussian_kernel);
         let right_term = lambda * variance * Array::eye(num_source_points);
         left_term + right_term
     };
-    let B = PX - Array::from_diag(sum_of_probability_rows).dot(source_points);
-    solve_matrices(&A, &B)
+    let matrix_b = PX - Array::from_diag(sum_of_probability_rows).dot(source_points);
+    solve_matrices(&matrix_a, &matrix_b)
 }
 
 fn update_variance(

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -3,8 +3,8 @@ extern crate openblas_src;
 use itertools::Itertools;
 use ndarray::{Array, ArrayBase, Axis, Dim, OwnedRepr, s, stack};
 use ndarray_linalg::Solve;
-use std::f32::consts::PI;
 use std::f32::EPSILON;
+use std::f32::consts::PI;
 
 struct CoherentPointDriftTransform {
     X: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
@@ -31,7 +31,7 @@ struct CoherentPointDriftTransform {
     G: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     num_eig: u32,
     history: Vec<String>,
-    debug: bool
+    debug: bool,
 }
 
 impl CoherentPointDriftTransform {
@@ -44,7 +44,7 @@ impl CoherentPointDriftTransform {
         tolerance: Option<f32>,
         max_iterations: Option<u32>,
         num_eig: Option<u32>,
-        debug: Option<bool>
+        debug: Option<bool>,
     ) -> CoherentPointDriftTransform {
         let num_target_points: usize = X.dim().0;
         let dimensions: usize = X.dim().1;
@@ -74,7 +74,7 @@ impl CoherentPointDriftTransform {
             G: gaussian_kernel(&Y, &Y, beta),
             num_eig: num_eig.unwrap_or(100),
             history: Vec::new(),
-            debug: debug.unwrap_or(false)
+            debug: debug.unwrap_or(false),
         }
     }
 
@@ -82,20 +82,22 @@ impl CoherentPointDriftTransform {
         self.transform_point_cloud();
         while self.iteration < self.max_iterations && self.diff > self.tolerance {
             if self.debug {
-                self.history.push(
-                    format!("\"{}\": {}", self.iteration, array_to_string(&self.TY))
-                );
+                self.history.push(format!(
+                    "\"{}\": {}",
+                    self.iteration,
+                    array_to_string(&self.TY)
+                ));
             }
             self.iterate();
         }
     }
-    
+
     fn transform_point_cloud(&mut self) {
         self.update_transform();
         let G = gaussian_kernel(&self.Y, &self.Y, self.beta);
         self.TY = self.Y.clone() + self.G.clone().dot(&self.W.clone());
     }
-    
+
     fn iterate(&mut self) {
         self.expectation();
         self.maximization();
@@ -104,16 +106,17 @@ impl CoherentPointDriftTransform {
 
     fn expectation(&mut self) {
         let mut P = ((compute_diff(&self.X, &self.TY)).powi(2)).sum_axis(Axis(2));
-        P = (-P/(2_f32*self.sigma2)).exp();
+        P = (-P / (2_f32 * self.sigma2)).exp();
         let c = {
-            let left = (2.0*PI*self.sigma2).powf((self.dimensions as f32)/2.0);
-            let right = self.w/(1.0-self.w)*(self.num_source_points as f32)/(self.num_target_points as f32);
+            let left = (2.0 * PI * self.sigma2).powf((self.dimensions as f32) / 2.0);
+            let right = self.w / (1.0 - self.w) * (self.num_source_points as f32)
+                / (self.num_target_points as f32);
             left * right
         };
         let mut den = P.sum_axis(Axis(0));
-        den = den.mapv(|v| if v == 0.0 {f32::EPSILON + c} else {v + c});
+        den = den.mapv(|v| if v == 0.0 { f32::EPSILON + c } else { v + c });
 
-        self.P = P.clone()/den;
+        self.P = P.clone() / den;
         self.Pt1 = self.P.clone().sum_axis(Axis(0));
         self.P1 = self.P.clone().sum_axis(Axis(1));
         self.Np = self.P1.sum();
@@ -136,12 +139,20 @@ impl CoherentPointDriftTransform {
         self.W = solve_matrices(&A, &B);
     }
 
-    fn update_variance(&mut self) { 
+    fn update_variance(&mut self) {
         let qprev = self.sigma2;
         self.q = f32::MAX;
-        let xPx = self.Pt1.clone().t().dot(&self.X.clone().powi(2).sum_axis(Axis(1)));
-        let yPy = self.P1.clone().t().dot(&self.TY.clone().powi(2).sum_axis(Axis(1)));
-        let trPXY = (self.TY.clone()*self.PX.clone()).sum();
+        let xPx = self
+            .Pt1
+            .clone()
+            .t()
+            .dot(&self.X.clone().powi(2).sum_axis(Axis(1)));
+        let yPy = self
+            .P1
+            .clone()
+            .t()
+            .dot(&self.TY.clone().powi(2).sum_axis(Axis(1)));
+        let trPXY = (self.TY.clone() * self.PX.clone()).sum();
 
         self.sigma2 = (xPx - 2.0 * trPXY + yPy) / (self.Np * self.dimensions as f32);
         if self.sigma2 <= 0.0 {
@@ -151,44 +162,39 @@ impl CoherentPointDriftTransform {
     }
 }
 
-
 // Non cpd functions.
 fn compute_diff(
     X: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>
+    Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> {
-    let X_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> = Array::from_shape_vec(
-        (1, X.dim().0, X.dim().1),
-        X.clone().into_raw_vec()
-    ).unwrap(); 
-    let Y_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> = Array::from_shape_vec(
-        (Y.dim().0, 1, Y.dim().1),
-        Y.clone().into_raw_vec()
-    ).unwrap();
+    let X_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> =
+        Array::from_shape_vec((1, X.dim().0, X.dim().1), X.clone().into_raw_vec()).unwrap();
+    let Y_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> =
+        Array::from_shape_vec((Y.dim().0, 1, Y.dim().1), Y.clone().into_raw_vec()).unwrap();
     X_3d - Y_3d
 }
 
 fn gaussian_kernel(
     X: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    beta: f32
+    beta: f32,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
     let X = X.clone();
     let Y = Y.clone();
     let diff = compute_diff(&X, &Y).powi(2).sum_axis(Axis(2));
-    (-diff/(2.0 * beta.powi(2))).exp()
+    (-diff / (2.0 * beta.powi(2))).exp()
 }
 
 fn initialize_sigma2(
     X: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>
+    Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
 ) -> f32 {
     let num_target_points = X.dim().0 as f32;
     let dimensions = X.dim().1 as f32;
     let num_source_points = Y.dim().0 as f32;
     let diff = compute_diff(X, Y);
     let err = diff.powi(2);
-    err.sum()/(dimensions*num_target_points*num_source_points)
+    err.sum() / (dimensions * num_target_points * num_source_points)
 }
 
 fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
@@ -198,7 +204,10 @@ fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
     let mut p_str: Vec<String> = Vec::new();
     for chunk in &chunks {
         let p: Vec<f32> = chunk.collect::<Vec<f32>>();
-        p_str.push(String::from(format!("{{\"x\": {}, \"y\": {}}}", p[0], p[1])));
+        p_str.push(String::from(format!(
+            "{{\"x\": {}, \"y\": {}}}",
+            p[0], p[1]
+        )));
     }
     let p_str: String = p_str.join(", ");
     arr_str.push_str(&p_str);

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -63,11 +63,8 @@ impl CoherentPointDriftTransform {
         let iteration = 0;
         while iteration < self.max_iterations && self.diff > self.tolerance {
             if self.debug {
-                self.history.push(format!(
-                    "\"{}\": {}",
-                    iteration,
-                    array_to_string(&self.TY)
-                ));
+                self.history
+                    .push(format!("\"{}\": {}", iteration, array_to_string(&self.TY)));
             }
             self.iterate();
             iteration += 1;
@@ -87,8 +84,8 @@ impl CoherentPointDriftTransform {
             let dimensions: usize = self.X.dim().1;
             let num_source_points: usize = self.Y.dim().0;
             let left = (2.0 * PI * self.sigma2).powf((dimensions as f32) / 2.0);
-            let right = self.w / (1.0 - self.w) * (num_source_points as f32)
-                / (num_target_points as f32);
+            let right =
+                self.w / (1.0 - self.w) * (num_source_points as f32) / (num_target_points as f32);
             left * right
         };
         let mut den = P.sum_axis(Axis(0));
@@ -123,11 +120,8 @@ impl CoherentPointDriftTransform {
         let B = PX.clone() - Array::from_diag(&P1.clone()).dot(&self.Y.clone());
         self.W = solve_matrices(&A, &B);
     }
-    
-    fn transform_point_cloud(
-        &mut self,
-        G: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    ) {
+
+    fn transform_point_cloud(&mut self, G: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) {
         self.TY = self.Y.clone() + G.clone().dot(&self.W.clone());
     }
 

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -179,7 +179,7 @@ fn transform_point_cloud(
     G: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     W: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
-    Y.clone() + G.clone().dot(&W.clone())
+    Y + G.dot(W)
 }
 
 fn update_transform(

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -109,7 +109,7 @@ impl CoherentPointDriftTransform {
         let PX = self.probability_of_match.dot(&self.target_points);
         let gaussian_kernel= compute_gaussian_kernel(&self.source_points, &self.source_points, self.beta);
 
-        self.W = update_transform(
+        self.W = compute_updated_transform(
             &self.source_points,
             &sum_of_probability_rows,
             &PX,
@@ -186,7 +186,7 @@ fn transform_point_cloud(
     source_points + gaussian_kernel.dot(W)
 }
 
-fn update_transform(
+fn compute_updated_transform(
     source_points: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     sum_of_probability_rows: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 1]>>,
     PX: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -39,7 +39,7 @@ impl CoherentPointDriftTransform {
         let num_source_points: usize = source_points.dim().0;
         let initial_variance: f32 = {
             let sum_sq_dists =
-                compute_squared_euclidean_distance(&target_points, &source_points).sum();
+                compute_squared_distance(&target_points, &source_points).sum();
             let denominator: f32 =
                 dimensions as f32 * num_target_points as f32 * num_source_points as f32;
             sum_sq_dists / denominator
@@ -84,7 +84,7 @@ impl CoherentPointDriftTransform {
 
     fn expectation(&mut self) {
         let mut P =
-            compute_squared_euclidean_distance(&self.target_points, &self.transformed_points);
+            compute_squared_distance(&self.target_points, &self.transformed_points);
         P = (-P / (2_f32 * self.variance)).exp();
         let c = {
             let num_target_points: usize = self.target_points.dim().0;
@@ -135,7 +135,7 @@ impl CoherentPointDriftTransform {
 }
 
 /// Computes the squared euclidean distance between all vectors in A and B.
-fn compute_squared_euclidean_distance(
+fn compute_squared_distance(
     matrix_a: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     matrix_b: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
@@ -158,7 +158,7 @@ fn compute_gaussian_kernel(
     matrix_b: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     beta: f32,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
-    let sum_sq_dists = compute_squared_euclidean_distance(matrix_a, matrix_b);
+    let sum_sq_dists = compute_squared_distance(matrix_a, matrix_b);
     (-sum_sq_dists / (2.0 * beta.powi(2))).exp()
 }
 

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -150,11 +150,11 @@ fn compute_squared_euclidean_distance(
 
 /// Computes the gaussian kernel for CPD.
 fn compute_gaussian_kernel(
-    A: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    B: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    matrix_a: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    matrix_b: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     beta: f32,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
-    let sum_sq_dists = compute_squared_euclidean_distance(A, B);
+    let sum_sq_dists = compute_squared_euclidean_distance(matrix_a, matrix_b);
     (-sum_sq_dists / (2.0 * beta.powi(2))).exp()
 }
 

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -101,6 +101,10 @@ impl CoherentPointDriftTransform {
 
     fn maximization(&mut self) {
         let sum_of_probability_rows = self.probability_of_match.sum_axis(Axis(1));
+        // Mathematically speaking, sum_of_probability_columns should always be
+        // a vector of approximately ones. However, I don't want to change the
+        // logic of the original author, so it stays.
+        // TODO: Test whether this is necessary.
         let sum_of_probability_columns = self.probability_of_match.sum_axis(Axis(0));
         let PX = self.probability_of_match.dot(&self.target_points);
         let G = gaussian_kernel(&self.source_points, &self.source_points, self.beta);

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -1,5 +1,6 @@
 extern crate openblas_src;
 
+use crate::annotations::point::Point;
 use itertools::Itertools;
 use ndarray::{Array, ArrayBase, Axis, Dim, OwnedRepr, s, stack};
 use ndarray_linalg::Solve;
@@ -79,6 +80,44 @@ impl CoherentPointDriftTransform {
             history: Vec::new(),
             debug: debug.unwrap_or(false),
         }
+    }
+
+    pub fn from_point_vectors(
+        target_points: Vec<Point>,
+        source_points: Vec<Point>,
+        lambda: f32,
+        beta: f32,
+        weight_of_uniform_dist: Option<f32>,
+        tolerance: Option<f32>,
+        max_iterations: Option<u32>,
+        debug: Option<bool>
+    ) -> CoherentPointDriftTransform {
+        let target_point_array: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> = {
+            let mut flattened_point_vec = Vec::new();
+            for p in target_points.iter() {
+                flattened_point_vec.push(p.x);
+                flattened_point_vec.push(p.y);
+            }
+            Array::from_shape_vec((target_points.len(), 2), flattened_point_vec).unwrap()
+        };
+        let source_point_array: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> = {
+            let mut flattened_point_vec = Vec::new();
+            for p in source_points.iter() {
+                flattened_point_vec.push(p.x);
+                flattened_point_vec.push(p.y);
+            }
+            Array::from_shape_vec((source_points.len(), 2), flattened_point_vec).unwrap()
+        };
+        CoherentPointDriftTransform::new(
+            target_point_array,
+            source_point_array,
+            lambda,
+            beta,
+            weight_of_uniform_dist,
+            tolerance,
+            max_iterations,
+            debug
+        )
     }
 
     pub fn register(&mut self) {

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -49,26 +49,6 @@ impl CoherentPointDriftTransform {
         let num_target_points: usize = X.dim().0;
         let dimensions: usize = X.dim().1;
         let num_source_points: usize = Y.dim().0;
-        let tolerance = match tolerance {
-            Some(v) => v,
-            None => 0.001
-        };
-        let max_iterations = match max_iterations {
-            Some(v) => v,
-            None => 100
-        };
-        let w = match w {
-            Some(v) => v,
-            None => 0.0
-        };
-        let num_eig = match num_eig {
-            Some(v) => v,
-            None => 100
-        };
-        let debug = match debug {
-            Some(v) => v,
-            None => false
-        };
         CoherentPointDriftTransform {
             X: X.clone(),
             Y: Y.clone(),
@@ -79,9 +59,9 @@ impl CoherentPointDriftTransform {
             num_target_points: num_target_points,
             num_source_points: num_source_points,
             D: dimensions,
-            tolerance: tolerance,
-            w: w,
-            max_iterations: max_iterations,
+            tolerance: tolerance.unwrap_or(0.001),
+            w: w.unwrap_or(0.0),
+            max_iterations: max_iterations.unwrap_or(100),
             iteration: 0,
             diff: f32::MAX,
             q: f32::MAX,
@@ -92,9 +72,9 @@ impl CoherentPointDriftTransform {
             Np: 0.0,
             W: Array::zeros((num_source_points, dimensions)),
             G: gaussian_kernel(&Y, &Y, beta),
-            num_eig: num_eig,
+            num_eig: num_eig.unwrap_or(100),
             history: Vec::new(),
-            debug: debug
+            debug: debug.unwrap_or(false)
         }
     }
 

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -66,14 +66,10 @@ impl CoherentPointDriftTransform {
                 self.history
                     .push(format!("\"{}\": {}", iteration, array_to_string(&self.TY)));
             }
-            self.iterate();
+            self.expectation();
+            self.maximization();
             iteration += 1;
         }
-    }
-
-    fn iterate(&mut self) {
-        self.expectation();
-        self.maximization();
     }
 
     fn expectation(&mut self) {

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -232,21 +232,21 @@ fn update_variance(
 }
 
 /// A helper function for converting a 2d array into a string representation.
-fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
-    let mut arr_str = String::from("[");
-    let arr = arr.clone();
-    let chunks = arr.into_iter().chunks(2);
-    let mut p_str: Vec<String> = Vec::new();
+fn array_to_string(array: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
+    let mut array_str = String::from("[");
+    let array = array.clone();
+    let chunks = array.into_iter().chunks(2);
+    let mut point_str: Vec<String> = Vec::new();
     for chunk in &chunks {
-        let p: Vec<f32> = chunk.collect::<Vec<f32>>();
-        p_str.push(String::from(format!(
+        let point: Vec<f32> = chunk.collect::<Vec<f32>>();
+        point_str.push(String::from(format!(
             "{{\"x\": {}, \"y\": {}}}",
-            p[0], p[1]
+            point[0], point[1]
         )));
     }
-    let p_str: String = p_str.join(", ");
-    arr_str.push_str(&p_str);
+    let point_str: String = point_str.join(", ");
+    array_str.push_str(&point_str);
 
-    arr_str.push_str("]");
-    arr_str
+    array_str.push_str("]");
+    array_str
 }

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -179,26 +179,6 @@ fn initialize_sigma2(
     sum_sq_dists.sum() / (dimensions * num_target_points * num_source_points)
 }
 
-/// A helper function for converting a 2d array into a string representation.
-fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
-    let mut arr_str = String::from("[");
-    let arr = arr.clone();
-    let chunks = arr.into_iter().chunks(2);
-    let mut p_str: Vec<String> = Vec::new();
-    for chunk in &chunks {
-        let p: Vec<f32> = chunk.collect::<Vec<f32>>();
-        p_str.push(String::from(format!(
-            "{{\"x\": {}, \"y\": {}}}",
-            p[0], p[1]
-        )));
-    }
-    let p_str: String = p_str.join(", ");
-    arr_str.push_str(&p_str);
-
-    arr_str.push_str("]");
-    arr_str
-}
-
 /// Computes the solution for a matrix equation AX = B.
 ///
 /// Goes column by column through B to find the vector that
@@ -219,4 +199,24 @@ fn solve_matrices(
     }
     let solutions = solutions.iter().map(|x| x.view()).collect::<Vec<_>>();
     stack(Axis(1), &solutions[..]).unwrap()
+}
+
+/// A helper function for converting a 2d array into a string representation.
+fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
+    let mut arr_str = String::from("[");
+    let arr = arr.clone();
+    let chunks = arr.into_iter().chunks(2);
+    let mut p_str: Vec<String> = Vec::new();
+    for chunk in &chunks {
+        let p: Vec<f32> = chunk.collect::<Vec<f32>>();
+        p_str.push(String::from(format!(
+            "{{\"x\": {}, \"y\": {}}}",
+            p[0], p[1]
+        )));
+    }
+    let p_str: String = p_str.join(", ");
+    arr_str.push_str(&p_str);
+
+    arr_str.push_str("]");
+    arr_str
 }

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -63,8 +63,10 @@ impl CoherentPointDriftTransform {
     }
 
     pub fn register(&mut self) {
-        let gaussian_kernel = compute_gaussian_kernel(&self.source_points, &self.source_points, self.beta);
-        self.transformed_points = transform_point_cloud(&self.source_points, &gaussian_kernel, &self.W);
+        let gaussian_kernel =
+            compute_gaussian_kernel(&self.source_points, &self.source_points, self.beta);
+        self.transformed_points =
+            compute_transformed_point_cloud(&self.source_points, &gaussian_kernel, &self.W);
         let mut iteration = 0;
         while iteration < self.max_iterations && self.change_in_variance > self.tolerance {
             if self.debug {
@@ -107,7 +109,8 @@ impl CoherentPointDriftTransform {
         // TODO: Test whether this is necessary.
         let sum_of_probability_columns = self.probability_of_match.sum_axis(Axis(0));
         let PX = self.probability_of_match.dot(&self.target_points);
-        let gaussian_kernel= compute_gaussian_kernel(&self.source_points, &self.source_points, self.beta);
+        let gaussian_kernel =
+            compute_gaussian_kernel(&self.source_points, &self.source_points, self.beta);
 
         self.W = compute_updated_transform(
             &self.source_points,
@@ -117,7 +120,8 @@ impl CoherentPointDriftTransform {
             self.lambda,
             self.variance,
         );
-        self.transformed_points = transform_point_cloud(&self.source_points, &gaussian_kernel, &self.W);
+        self.transformed_points =
+            compute_transformed_point_cloud(&self.source_points, &gaussian_kernel, &self.W);
         (self.variance, self.change_in_variance) = update_variance(
             &self.target_points,
             &self.transformed_points,
@@ -178,7 +182,7 @@ fn solve_matrices(
     stack(Axis(1), &solutions[..]).unwrap()
 }
 
-fn transform_point_cloud(
+fn compute_transformed_point_cloud(
     source_points: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     gaussian_kernel: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     W: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -19,7 +19,6 @@ struct CoherentPointDriftTransform {
     change_in_variance: f32,
     probability_of_match: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     W: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    num_eig: u32,
     history: Vec<String>, // Contains all the TY matrices for all iterations for debugging.
     debug: bool,          // Whether or not to take a history.
 }
@@ -33,7 +32,6 @@ impl CoherentPointDriftTransform {
         w: Option<f32>,
         tolerance: Option<f32>,
         max_iterations: Option<u32>,
-        num_eig: Option<u32>,
         debug: Option<bool>,
     ) -> CoherentPointDriftTransform {
         let num_target_points: usize = X.dim().0;
@@ -52,7 +50,6 @@ impl CoherentPointDriftTransform {
             change_in_variance: f32::MAX,
             probability_of_match: Array::zeros((num_source_points, num_target_points)),
             W: Array::zeros((num_source_points, dimensions)),
-            num_eig: num_eig.unwrap_or(100),
             history: Vec::new(),
             debug: debug.unwrap_or(false),
         }

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -9,7 +9,7 @@ use std::f32::EPSILON;
 struct CoherentPointDriftTransform {
     X: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     Y: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    alpha: f32,
+    lambda: f32,
     beta: f32,
     TY: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     sigma2: f32,
@@ -38,7 +38,7 @@ impl CoherentPointDriftTransform {
     pub fn new(
         X: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
         Y: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-        alpha: f32,
+        lambda: f32,
         beta: f32,
         w: Option<f32>,
         tolerance: Option<f32>,
@@ -72,7 +72,7 @@ impl CoherentPointDriftTransform {
         CoherentPointDriftTransform {
             X: X.clone(),
             Y: Y.clone(),
-            alpha: alpha,
+            lambda: lambda,
             beta: beta,
             TY: Y.clone(),
             sigma2: initialize_sigma2(&X, &Y),
@@ -149,7 +149,7 @@ impl CoherentPointDriftTransform {
     fn update_transform(&mut self) {
         let A = {
             let left_term = Array::from_diag(&self.P1.clone()).dot(&self.G.clone());
-            let right_term = self.alpha * self.sigma2 * Array::eye(self.M.clone());
+            let right_term = self.lambda * self.sigma2 * Array::eye(self.M.clone());
             left_term + right_term
         };
         let B = self.PX.clone() - Array::from_diag(&self.P1.clone()).dot(&self.Y.clone());

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -164,15 +164,15 @@ fn compute_gaussian_kernel(
 /// solves that equation and then contatenates all the solution
 /// vectors as columns in the resulting matrix.
 fn solve_matrices(
-    A: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    B: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    matrix_a: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    matrix_b: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
-    let num_cols = B.dim().1;
+    let num_cols = matrix_b.dim().1;
     let mut solutions: Vec<_> = Vec::new();
-    for c in 0..num_cols {
-        let col = B.slice(s![.., c]).to_owned();
-        let soln = A.solve_into(col).unwrap();
-        solutions.push(soln);
+    for column_ix in 0..num_cols {
+        let col = matrix_b.slice(s![.., column_ix]).to_owned();
+        let solution = matrix_a.solve_into(col).unwrap();
+        solutions.push(solution);
     }
     let solutions = solutions.iter().map(|x| x.view()).collect::<Vec<_>>();
     stack(Axis(1), &solutions[..]).unwrap()

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -1,0 +1,245 @@
+extern crate openblas_src;
+
+use itertools::Itertools;
+use ndarray::{Array, ArrayBase, Axis, Dim, OwnedRepr, s, stack};
+use ndarray_linalg::Solve;
+use std::f32::consts::PI;
+use std::f32::EPSILON;
+
+struct CoherentPointDriftTransform {
+    X: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    Y: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    alpha: f32,
+    beta: f32,
+    TY: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    sigma2: f32,
+    N: usize,
+    M: usize,
+    D: usize,
+    tolerance: f32,
+    w: f32,
+    max_iterations: u32,
+    iteration: u32,
+    diff: f32,
+    q: f32,
+    P: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    Pt1: ArrayBase<OwnedRepr<f32>, Dim<[usize; 1]>>,
+    P1: ArrayBase<OwnedRepr<f32>, Dim<[usize; 1]>>,
+    PX: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    Np: f32,
+    W: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    G: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    num_eig: u32,
+    history: Vec<String>,
+    debug: bool
+}
+
+impl CoherentPointDriftTransform {
+    pub fn new(
+        X: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+        Y: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+        alpha: f32,
+        beta: f32,
+        w: Option<f32>,
+        tolerance: Option<f32>,
+        max_iterations: Option<u32>,
+        num_eig: Option<u32>,
+        debug: Option<bool>
+    ) -> CoherentPointDriftTransform {
+        let num_target_points: usize = X.dim().0;
+        let dimensions: usize = X.dim().1;
+        let num_source_points: usize = Y.dim().0;
+        let tolerance = match tolerance {
+            Some(v) => v,
+            None => 0.001
+        };
+        let max_iterations = match max_iterations {
+            Some(v) => v,
+            None => 100
+        };
+        let w = match w {
+            Some(v) => v,
+            None => 0.0
+        };
+        let num_eig = match num_eig {
+            Some(v) => v,
+            None => 100
+        };
+        let debug = match debug {
+            Some(v) => v,
+            None => false
+        };
+        CoherentPointDriftTransform {
+            X: X.clone(),
+            Y: Y.clone(),
+            alpha: alpha,
+            beta: beta,
+            TY: Y.clone(),
+            sigma2: initialize_sigma2(&X, &Y),
+            N: num_target_points,
+            M: num_source_points,
+            D: dimensions,
+            tolerance: tolerance,
+            w: w,
+            max_iterations: max_iterations,
+            iteration: 0,
+            diff: f32::MAX,
+            q: f32::MAX,
+            P: Array::zeros((num_source_points, num_target_points)),
+            Pt1: Array::zeros(num_target_points),
+            P1: Array::zeros(num_source_points),
+            PX: Array::zeros((num_source_points, dimensions)),
+            Np: 0.0,
+            W: Array::zeros((num_source_points, dimensions)),
+            G: gaussian_kernel(&Y, &Y, beta),
+            num_eig: num_eig,
+            history: Vec::new(),
+            debug: debug
+        }
+    }
+
+    pub fn register(&mut self) {
+        self.transform_point_cloud();
+        while self.iteration < self.max_iterations && self.diff > self.tolerance {
+            if self.debug {
+                self.history.push(
+                    format!("\"{}\": {}", self.iteration, array_to_string(&self.TY))
+                );
+            }
+            self.iterate();
+        }
+    }
+    
+    fn transform_point_cloud(&mut self) {
+        self.update_transform();
+        let G = gaussian_kernel(&self.Y, &self.Y, self.beta);
+        self.TY = self.Y.clone() + self.G.clone().dot(&self.W.clone());
+    }
+    
+    fn iterate(&mut self) {
+        self.expectation();
+        self.maximization();
+        self.iteration += 1;
+    }
+
+    fn expectation(&mut self) {
+        let mut P = ((compute_diff(&self.X, &self.TY)).powi(2)).sum_axis(Axis(2));
+        P = (-P/(2_f32*self.sigma2)).exp();
+        let c = {
+            let left = (2.0*PI*self.sigma2).powf((self.D as f32)/2.0);
+            let right = self.w/(1.0-self.w)*(self.M as f32)/(self.N as f32);
+            left * right
+        };
+        let mut den = P.sum_axis(Axis(0));
+        den = den.mapv(|v| if v == 0.0 {f32::EPSILON + c} else {v + c});
+
+        self.P = P.clone()/den;
+        self.Pt1 = self.P.clone().sum_axis(Axis(0));
+        self.P1 = self.P.clone().sum_axis(Axis(1));
+        self.Np = self.P1.sum();
+        self.PX = self.P.clone().dot(&self.X);
+    }
+
+    fn maximization(&mut self) {
+        self.update_transform();
+        self.transform_point_cloud();
+        self.update_variance();
+    }
+
+    fn update_transform(&mut self) {
+        let A = {
+            let left_term = Array::from_diag(&self.P1.clone()).dot(&self.G.clone());
+            let right_term = self.alpha * self.sigma2 * Array::eye(self.M.clone());
+            left_term + right_term
+        };
+        let B = self.PX.clone() - Array::from_diag(&self.P1.clone()).dot(&self.Y.clone());
+        self.W = solve_matrices(&A, &B);
+    }
+
+    fn update_variance(&mut self) { 
+        let qprev = self.sigma2;
+        self.q = f32::MAX;
+        let xPx = self.Pt1.clone().t().dot(&self.X.clone().powi(2).sum_axis(Axis(1)));
+        let yPy = self.P1.clone().t().dot(&self.TY.clone().powi(2).sum_axis(Axis(1)));
+        let trPXY = (self.TY.clone()*self.PX.clone()).sum();
+
+        self.sigma2 = (xPx - 2.0 * trPXY + yPy) / (self.Np * self.D as f32);
+        if self.sigma2 <= 0.0 {
+            self.sigma2 = self.tolerance / 10.0;
+        }
+        self.diff = (self.sigma2 - qprev).abs();
+    }
+}
+
+
+// Non cpd functions.
+fn compute_diff(
+    X: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>
+) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> {
+    let X_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> = Array::from_shape_vec(
+        (1, X.dim().0, X.dim().1),
+        X.clone().into_raw_vec()
+    ).unwrap(); 
+    let Y_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> = Array::from_shape_vec(
+        (Y.dim().0, 1, Y.dim().1),
+        Y.clone().into_raw_vec()
+    ).unwrap();
+    X_3d - Y_3d
+}
+
+fn gaussian_kernel(
+    X: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    beta: f32
+) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
+    let X = X.clone();
+    let Y = Y.clone();
+    let diff = compute_diff(&X, &Y).powi(2).sum_axis(Axis(2));
+    (-diff/(2.0 * beta.powi(2))).exp()
+}
+
+fn initialize_sigma2(
+    X: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    Y: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>
+) -> f32 {
+    let N = X.dim().0 as f32;
+    let D = X.dim().1 as f32;
+    let M = Y.dim().0 as f32;
+    let diff = compute_diff(X, Y);
+    let err = diff.powi(2);
+    err.sum()/(D*N*M)
+}
+
+fn array_to_string(arr: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>) -> String {
+    let mut arr_str = String::from("[");
+    let arr = arr.clone();
+    let chunks = arr.into_iter().chunks(2);
+    let mut p_str: Vec<String> = Vec::new();
+    for chunk in &chunks {
+        let p: Vec<f32> = chunk.collect::<Vec<f32>>();
+        p_str.push(String::from(format!("{{\"x\": {}, \"y\": {}}}", p[0], p[1])));
+    }
+    let p_str: String = p_str.join(", ");
+    arr_str.push_str(&p_str);
+
+    arr_str.push_str("]");
+    arr_str
+}
+
+fn solve_matrices(
+    A: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    B: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
+    let A = A.clone();
+    let B = B.clone();
+    let num_cols = B.dim().1;
+    let mut solutions: Vec<_> = Vec::new();
+    for c in 0..num_cols {
+        let col = B.slice(s![.., c]).to_owned();
+        let soln = A.solve_into(col).unwrap();
+        solutions.push(soln);
+    }
+    let solutions = solutions.iter().map(|x| x.view()).collect::<Vec<_>>();
+    stack(Axis(1), &solutions[..]).unwrap()
+}

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -17,7 +17,7 @@ struct CoherentPointDriftTransform {
     w: f32,
     max_iterations: u32,
     change_in_variance: f32,
-    P: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    probability_of_match: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     W: ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
     num_eig: u32,
     history: Vec<String>, // Contains all the TY matrices for all iterations for debugging.
@@ -50,7 +50,7 @@ impl CoherentPointDriftTransform {
             w: w.unwrap_or(0.0),
             max_iterations: max_iterations.unwrap_or(100),
             change_in_variance: f32::MAX,
-            P: Array::zeros((num_source_points, num_target_points)),
+            probability_of_match: Array::zeros((num_source_points, num_target_points)),
             W: Array::zeros((num_source_points, dimensions)),
             num_eig: num_eig.unwrap_or(100),
             history: Vec::new(),
@@ -87,13 +87,13 @@ impl CoherentPointDriftTransform {
         let mut den = P.sum_axis(Axis(0));
         den = den.mapv(|v| if v == 0.0 { f32::EPSILON + c } else { v + c });
 
-        self.P = P.clone() / den;
+        self.probability_of_match = P.clone() / den;
     }
 
     fn maximization(&mut self) {
-        let P1 = self.P.clone().sum_axis(Axis(1));
-        let Pt1 = self.P.clone().sum_axis(Axis(0));
-        let PX = self.P.clone().dot(&self.X);
+        let P1 = self.probability_of_match.clone().sum_axis(Axis(1));
+        let Pt1 = self.probability_of_match.clone().sum_axis(Axis(0));
+        let PX = self.probability_of_match.clone().dot(&self.X);
         let G = gaussian_kernel(&self.Y, &self.Y, self.beta);
 
         self.update_transform(&P1, &PX, &G);

--- a/src/registration/coherent_point_drift.rs
+++ b/src/registration/coherent_point_drift.rs
@@ -132,20 +132,20 @@ impl CoherentPointDriftTransform {
 
 /// Computes the squared euclidean distance between all vectors in A and B.
 fn compute_squared_euclidean_distance(
-    A: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
-    B: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    matrix_a: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
+    matrix_b: &ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>>,
 ) -> ArrayBase<OwnedRepr<f32>, Dim<[usize; 2]>> {
-    let A_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> = Array::from_shape_vec(
-        (1, A.dim().0, A.dim().1),
-        A.clone().into_raw_vec_and_offset().0,
+    let matrix_a_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> = Array::from_shape_vec(
+        (1, matrix_a.dim().0, matrix_a.dim().1),
+        matrix_a.clone().into_raw_vec_and_offset().0,
     )
     .unwrap();
-    let B_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> = Array::from_shape_vec(
-        (B.dim().0, 1, B.dim().1),
-        B.clone().into_raw_vec_and_offset().0,
+    let matrix_b_3d: ArrayBase<OwnedRepr<f32>, Dim<[usize; 3]>> = Array::from_shape_vec(
+        (matrix_b.dim().0, 1, matrix_b.dim().1),
+        matrix_b.clone().into_raw_vec_and_offset().0,
     )
     .unwrap();
-    (A_3d - B_3d).powi(2).sum_axis(Axis(2))
+    (matrix_a_3d - matrix_b_3d).powi(2).sum_axis(Axis(2))
 }
 
 /// Computes the gaussian kernel for CPD.

--- a/src/registration/mod.rs
+++ b/src/registration/mod.rs
@@ -1,1 +1,2 @@
+pub mod coherent_point_drift;
 pub mod thin_plate_splines;


### PR DESCRIPTION
Adds a module to perform the coherent point drift algorithm.

The logic is based off of the [pycpd library](https://github.com/siavashk/pycpd/tree/master), with some major modifications and changes to Rust.